### PR TITLE
Restructure and allow for definitions to exist within the module instead of at node level

### DIFF
--- a/modules/vividcortex/manifests/config.pp
+++ b/modules/vividcortex/manifests/config.pp
@@ -1,0 +1,22 @@
+## vividcortex::config will ensure that all the configuration files are in place
+class vividcortex::config{
+
+  # Ensure the vc path exists after the vc-release package is installed
+  file { $params::vc_path :
+    ensure  => directory,
+    owner   => root,
+    group   => root,
+    mode    => '0700',
+    require => Package[$params::vc_packages],
+  }
+
+  # vc config, requires the vc-release package to be installed
+  file { "${params::vc_path}global.conf":
+    ensure  => present,
+    content => template('vividcortex/global.conf.erb'),
+    require => [Package["$params::vc_packages"], File["$params::vc_path"]],
+    notify  => Service["vividcortex"],
+  }
+
+
+}

--- a/modules/vividcortex/manifests/init.pp
+++ b/modules/vividcortex/manifests/init.pp
@@ -15,14 +15,15 @@
 
 
 class vividcortex(
-    $apitoken = $apitoken,
-    $cdnuri = $cdnuri,
-    $apiuri = $apiuri,
-    $proxyuri = $proxyuri) {
+  $apitoken = $vc_apitoken,
+  $cdnuri = $vc_cdnuri,
+  $apiuri = $vc_apiuri,
+  $proxyuri = $vc_proxyuri
+  ) inherits vividcortex::params {
 
     include vividcortex::params
-    include vividcortex::config
     include vividcortex::packages
+    include vividcortex::config
     include vividcortex::services
 
 }

--- a/modules/vividcortex/manifests/init.pp
+++ b/modules/vividcortex/manifests/init.pp
@@ -1,27 +1,27 @@
-class vividcortex($apitoken, $cdnuri = '', $apiuri = '', $proxyuri = '') {
+##
+## In order to utilize this module the you must, at a minimum, update params.pp with your
+##  apitoken. Otherwise, declare as follows
+##
+## node { x:
+##    include vividcortex('apitoken')
+## }
+##
+## the following paramaters are optional for the delcaration
+##   cdnuri
+##   apiuri
+##   proxyuri
+##
+##
 
-    package { 'vividcortex-release':
-        ensure => present,
-        source => 'https://repo.vividcortex.com/repo/centos/6/x86_64/vividcortex-release-1-1.el6.noarch.rpm',
-        provider => rpm,
-    }
-    package { 'vividcortex-agents':
-        ensure => latest,
-        require => Package["vividcortex-release"],
-    }
-    file { 'vividcortex-dir':
-        path => '/etc/vividcortex/',
-        ensure => directory,
-        owner => 'root',
-        group => 'root',
-        mode => '0700',
-    }
-    file { 'vividcortex-config':
-        path => '/etc/vividcortex/global.conf',
-        owner => 'root',
-        group => 'root',
-        mode => '0600',
-        content => template('vividcortex/global.conf.erb'),
-    }
+class vividcortex(
+    $apitoken = $params::apitoken,
+    $cdnuri = $params::cdnuri,
+    $apiuri = $params::apiuri,
+    $proxyuri = $params::proxyuri) {
+
+    include vividcortex::params
+    include vividcortex::config
+    include vividcortex::packages
+    include vividcortex::services
 
 }

--- a/modules/vividcortex/manifests/init.pp
+++ b/modules/vividcortex/manifests/init.pp
@@ -13,11 +13,12 @@
 ##
 ##
 
+
 class vividcortex(
-    $apitoken = $params::apitoken,
-    $cdnuri = $params::cdnuri,
-    $apiuri = $params::apiuri,
-    $proxyuri = $params::proxyuri) {
+    $apitoken = $apitoken,
+    $cdnuri = $cdnuri,
+    $apiuri = $apiuri,
+    $proxyuri = $proxyuri) {
 
     include vividcortex::params
     include vividcortex::config

--- a/modules/vividcortex/manifests/packages.pp
+++ b/modules/vividcortex/manifests/packages.pp
@@ -1,0 +1,14 @@
+## vividcortex::packages will ensure packages in params.pp are installed
+class vividcortex::packages{
+
+  package { $params::vc_repo:
+    ensure => present,
+    source => $params::vc_repo_source,
+  }
+
+  package { $params::vc_packages:
+    ensure  => latest,
+    require => Package[$params::vc_repo],
+  }
+
+}

--- a/modules/vividcortex/manifests/packages.pp
+++ b/modules/vividcortex/manifests/packages.pp
@@ -2,8 +2,9 @@
 class vividcortex::packages{
 
   package { $params::vc_repo:
-    ensure => present,
-    source => $params::vc_repo_source,
+    ensure   => present,
+    source   => $params::vc_repo_source,
+    provider => rpm
   }
 
   package { $params::vc_packages:

--- a/modules/vividcortex/manifests/params.pp
+++ b/modules/vividcortex/manifests/params.pp
@@ -1,0 +1,17 @@
+## vividcortex::params contains all variables relating to this module
+class vividcortex::params{
+  
+  $vc_repo = ['vividcortex-release']
+  $vc_packages = ['vividcortex-agents']
+
+  $vc_repo_source = 'https://repo.vividcortex.com/repo/centos/6/x86_64/vividcortex-release-1-1.el6.noarch.rpm'
+
+  $vc_path  = "/etc/vividcortex/"
+
+  $apitoken = ''
+  $cdnuri = ''
+  $apiuri = ''
+  $proxyuri = ''
+
+}
+

--- a/modules/vividcortex/manifests/params.pp
+++ b/modules/vividcortex/manifests/params.pp
@@ -8,10 +8,9 @@ class vividcortex::params{
 
   $vc_path  = "/etc/vividcortex/"
 
-  $apitoken = ''
-  $cdnuri = ''
-  $apiuri = ''
-  $proxyuri = ''
-
+  $vc_apitoken = ''
+  $vc_cdnuri = ''
+  $vc_apiuri = ''
+  $vc_proxyuri = ''
 }
 

--- a/modules/vividcortex/manifests/services.pp
+++ b/modules/vividcortex/manifests/services.pp
@@ -2,7 +2,7 @@ class vividcortex::services{
 
   service { "vividcortex":
     ensure  => running,
-    require => Package[$params::vc_packages]
+    require => [Package[$params::vc_packages],File["${params::vc_path}global.conf"]]
   }
 
 }

--- a/modules/vividcortex/manifests/services.pp
+++ b/modules/vividcortex/manifests/services.pp
@@ -1,0 +1,7 @@
+class vividcortex::services{
+
+  service { "vividcortex":
+    ensure  => running,
+  }
+
+}

--- a/modules/vividcortex/manifests/services.pp
+++ b/modules/vividcortex/manifests/services.pp
@@ -2,6 +2,7 @@ class vividcortex::services{
 
   service { "vividcortex":
     ensure  => running,
+    require => Package[$params::vc_packages]
   }
 
 }

--- a/modules/vividcortex/templates/global.conf.erb
+++ b/modules/vividcortex/templates/global.conf.erb
@@ -2,5 +2,5 @@
     "api-token": "<%= @apitoken %>"<% if @proxyuri != "" %>,
     "proxy-url": "<%= @proxyuri %>"<% end %><% if @apiuri != "" %>,
     "api-uri": "<%= @apiuri %>"<% end %><% if @cdnuri != "" %>,
-    "cdn-uri": "<%= @cdnuri %>"<% end %>,
+    "cdn-uri": "<%= @cdnuri %>"<% end %>
 }


### PR DESCRIPTION
- Restructured to align with puppetlabs standards
- Allowed for definitions to occur within params.pp such that node definitions can just be 'include vividcortex' (helpful for applying to multiple nodes)
- Allowed for definitions to be overridden on a per node basis (helpful for one off nodes)
- Fixed template as by default would append a comma to a single line defined config
